### PR TITLE
chore: dependency updates and version bump (`0.2.0`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic-buf-build"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "A build helper that integrates buf.build to tonic-build."
 license = "MIT"
@@ -9,9 +9,9 @@ repository = "https://github.com/Valensas/tonic-buf-build"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tonic-build = "0.10.0"
+tonic-build = "0.11"
 serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9.22"
-uuid = { version = "1.2.2", features = ["v4", "fast-rng"] }
-prost-build = "0.12.1"
-scopeguard = "1.2.0"
+serde_yaml = "0.9"
+uuid = { version = "1.2", features = ["v4", "fast-rng"] }
+prost-build = "0.12"
+scopeguard = "1.2"


### PR DESCRIPTION
Update `tonic-build` to 0.11 and remove patch version requirement from all dependencies