### PR TITLE
configurable buf path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic-buf-build"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "A build helper that integrates buf.build to tonic-build."
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -25,3 +25,23 @@ fn main() -> Result<(), tonic_buf_build::error::TonicBufBuildError> {
 To use buf workspaces, simply call `tonic_buf_build::compile_from_buf_workspace` instead.
 
 For complete and working examples, take a look at the examples folder.
+
+When the buf files are not located not in the current directory, you can configure the *absolute* path to the directory, containing either `buf.yaml` or `buf.work.yaml`, and call the corresponding `tonic_buf_build::compile_from_buf_with_config` or `tonic_buf_build::compile_from_buf_workspace_with_config`.
+
+Consider the following build.rs where the workspace directory is located one level above the crate (a usual case for multilanguage clients with common protos)
+
+```rust
+use std::env;
+use std::path::PathBuf;
+
+fn main() -> Result<(), tonic_buf_build::error::TonicBufBuildError> {
+    let mut path = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    path.pop();
+    tonic_buf_build::compile_from_buf_workspace_with_config(
+        tonic_build::configure(),
+        None,
+        tonic_buf_build::TonicBufConfig{buf_dir: Some(path)},
+    )?;
+    Ok(())
+}
+```

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ To use buf workspaces, simply call `tonic_buf_build::compile_from_buf_workspace`
 
 For complete and working examples, take a look at the examples folder.
 
-When the buf files are not located not in the current directory, you can configure the *absolute* path to the directory, containing either `buf.yaml` or `buf.work.yaml`, and call the corresponding `tonic_buf_build::compile_from_buf_with_config` or `tonic_buf_build::compile_from_buf_workspace_with_config`.
+When the buf files are not located in the current directory, you can configure the *absolute* path to the directory, containing either `buf.yaml` or `buf.work.yaml`, and call the corresponding `tonic_buf_build::compile_from_buf_with_config` or `tonic_buf_build::compile_from_buf_workspace_with_config`.
 
-Consider the following build.rs where the workspace directory is located one level above the crate (a usual case for multilanguage clients with common protos)
+Consider the following build.rs where the buf workspace directory is located one level above the crate (a usual case for multilanguage clients with common protos)
 
 ```rust
 use std::env;


### PR DESCRIPTION
Hi guys!

Thanks a lot for this crate! This PR while preserving current public API, introduces their configurable counterparts to specify the directory of the buf spec files. This is useful for cases of repos where multiple implementations coexist with the same protos set.