### PR TITLE
chore: dependency updates and version bump (`0.3.0`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic-buf-build"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "A build helper that integrates buf.build to tonic-build."
 license = "MIT"
@@ -9,9 +9,9 @@ repository = "https://github.com/Valensas/tonic-buf-build"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tonic-build = "0.11"
+tonic-build = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
-uuid = { version = "1.2", features = ["v4", "fast-rng"] }
-prost-build = "0.12"
+uuid = { version = "1.10", features = ["v4", "fast-rng"] }
+prost-build = "0.13"
 scopeguard = "1.2"

--- a/examples/buf-work-yaml/Cargo.toml
+++ b/examples/buf-work-yaml/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tonic = {version = "0.10.0", features = ["tls"]}
-tokio = {version = "1.28.2", features = ["full"]}
-prost = "0.12.1"
+tonic = {version = "0.12.3", features = ["tls"]}
+tokio = {version = "1.40.0", features = ["full"]}
+prost = "0.13.3"
 
 [build-dependencies]
 tonic-buf-build = {path = "../../"}

--- a/examples/buf-yaml/Cargo.toml
+++ b/examples/buf-yaml/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-tonic = {version = "0.10.0", features = ["tls"]}
-tokio = {version = "1.28.2", features = ["full"]}
-prost = "0.12.1"
+tonic = {version = "0.12.3", features = ["tls"]}
+tokio = {version = "1.40.0", features = ["full"]}
+prost = "0.13.3"
 
 [build-dependencies]
 tonic-buf-build = {path = "../../"}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,8 +84,8 @@ pub fn compile_from_buf_workspace_with_config<P: AsRef<Path>>(
     let protos = buf::ls_files(buf_dir)?;
 
     match config {
-        None => tonic_builder.compile(&protos, &includes),
-        Some(config) => tonic_builder.compile_with_config(config, &protos, &includes),
+        None => tonic_builder.compile_protos(&protos, &includes),
+        Some(config) => tonic_builder.compile_protos_with_config(config, &protos, &includes),
     }
     .map_err(|e| TonicBufBuildError::new("error running tonic build", e.into()))
 }
@@ -121,8 +121,8 @@ pub fn compile_from_buf_with_config<P: AsRef<Path>>(
     let includes = [buf_dir, &export_dir];
 
     match config {
-        None => tonic_builder.compile(&protos, &includes),
-        Some(config) => tonic_builder.compile_with_config(config, &protos, &includes),
+        None => tonic_builder.compile_protos(&protos, &includes),
+        Some(config) => tonic_builder.compile_protos_with_config(config, &protos, &includes),
     }
     .map_err(|e| TonicBufBuildError::new("error running tonic build", e.into()))
 }


### PR DESCRIPTION
Mainly for the `tonic-build` dep update to `0.12`, and `prost-build` dep update to `0.13`. Bumps crate to `0.3.0`.
Let me know if something needs to be improved! Thanks!