### PR TITLE
chore: dependency updates and version bump (`0.3.1`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic-buf-build"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "A build helper that integrates buf.build to tonic-build."
 license = "MIT"
@@ -9,7 +9,7 @@ repository = "https://github.com/Valensas/tonic-buf-build"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tonic-build = "0.12"
+tonic-build = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 uuid = { version = "1.10", features = ["v4", "fast-rng"] }

--- a/examples/buf-work-yaml/Cargo.toml
+++ b/examples/buf-work-yaml/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "buf-work-yaml"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tonic = {version = "0.12.3", features = ["tls"]}
+tonic = "0.13"
 tokio = {version = "1.40.0", features = ["full"]}
 prost = "0.13.3"
 

--- a/examples/buf-yaml/Cargo.toml
+++ b/examples/buf-yaml/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "buf-yaml"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-tonic = {version = "0.12.3", features = ["tls"]}
+tonic = "0.13"
 tokio = {version = "1.40.0", features = ["full"]}
 prost = "0.13.3"
 


### PR DESCRIPTION
Hi! Thanks for the package. Tonic recently rolled out 0.13 so here's a PR updating the relevant dependancies. Thanks!