### PR TITLE
Updating tonic version and fixing external proto compilations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic-buf-build"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "A build helper that integrates buf.build to tonic-build."
 license = "MIT"
@@ -9,9 +9,8 @@ repository = "https://github.com/Valensas/tonic-buf-build"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tonic-build = "0.12"
+tonic-build = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 uuid = { version = "1.10", features = ["v4", "fast-rng"] }
-prost-build = "0.13"
 scopeguard = "1.2"


### PR DESCRIPTION
This pull request implements two issues separately:

- Updates tonic library to the latest released version
- Fixes the issue of not finding any protos if protos are not located on the local repository but are actually only fetchable via buf